### PR TITLE
Fix: Remove duplicate strings

### DIFF
--- a/plugin/vim-fzf-coauthorship.vim
+++ b/plugin/vim-fzf-coauthorship.vim
@@ -7,7 +7,7 @@ function! Coauthorship()
   call fzf#run({
     \ 'source': 'git log --pretty="%an <%ae>" | sort | uniq',
     \ 'sink': function('AttributeCoauthorship'),
-    \ 'options': "--preview 'git log -1 --author {} --pretty=\"authored %h %ar:%n%n%B\"'"
+    \ 'options': "-i --preview 'git log -1 --author {} --pretty=\"authored %h %ar:%n%n%B\"'"
     \ })
 endfunction
 


### PR DESCRIPTION
That only differ on casing.

E.g.
```
X10an14@noreply.com
x10an14@noreply.com
```

should both be combined into one alternative for `fzf`.